### PR TITLE
docs: add voting overview and integration plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,36 @@ supernova-federate vote <fork_id> --voter Bob --vote yes
 The UI listens on [http://localhost:8888](http://localhost:8888) by default.
 Append `?healthz=1` to the URL and you should see `ok` when the server is running.
 
+## 🗳️ How voting works
+
+STRICTLY A SOCIAL MEDIA PLATFORM
+Intellectual Property & Artistic Inspiration
+Legal & Ethical Safeguards
+
+Weighted voting divides influence equally among the species that participate. If
+humans, companies, and AIs all vote on a proposal, each species controls one
+third of the total weight. Within a species, weight is split evenly among its
+voters. Decisions require a super‑majority of the weighted "yes" votes:
+
+- **Standard matters:** accepted at **60 %** or more yes votes.
+- **Important matters:** accepted at **90 %** or more yes votes.
+
+## ⏱️ One‑minute demo
+
+To see the weighted engine in action with sample data:
+
+1. Launch the interface:
+   ```bash
+   streamlit run ui.py
+   ```
+2. In the sidebar, open **Proposals (Weighted)**.
+3. Vote on a proposal as a human, company, or AI and watch the live weighted
+   tally update.
+4. Toggle between standard and important levels to observe the 60 % vs. 90 %
+   acceptance thresholds.
+
+For integration guidance, see the [Integration Plan](docs/INTEGRATION_PLAN.md).
+
 ## 🔧 Local Development
 
 To launch the Streamlit UI:

--- a/docs/INTEGRATION_PLAN.md
+++ b/docs/INTEGRATION_PLAN.md
@@ -1,0 +1,26 @@
+# Integration Plan
+
+STRICTLY A SOCIAL MEDIA PLATFORM
+Intellectual Property & Artistic Inspiration
+Legal & Ethical Safeguards
+
+This document outlines how the weighted voting interface connects with other modules in the system.
+
+## Goals
+- Enable smooth adoption of the weighted voting engine.
+- Provide guidance for developers integrating the UI with backend services.
+
+## Steps
+1. **Prerequisites**
+   - Ensure the core services and the Streamlit UI are installed.
+   - Confirm that `voting_engine.py` is available for species-based weighting.
+2. **API Wiring**
+   - Use `external_services.fake_api_weighted` as a reference implementation.
+   - Connect your backend to expose compatible `vote`, `tally`, and `decide` endpoints.
+3. **UI Hooks**
+   - The page `pages/proposals_weighted.py` demonstrates how to render weighted tallies.
+   - Replace the fake API calls with real network requests as needed.
+4. **Testing**
+   - Run `make test` to ensure new integrations do not break existing functionality.
+
+For more details or to propose changes, open an issue or submit a pull request.


### PR DESCRIPTION
## Summary
- explain weighted voting with species shares and 60%/90% decision thresholds
- document a one-minute demo using `streamlit run ui.py`
- add integration plan doc and link from the README

## Testing
- `make test` *(fails: AttributeError: module 'ui' has no attribute '_determine_backend', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68955cbcd4248320b10fce8d23136218