### PR TITLE
Centralize species selection in weighted proposals

### DIFF
--- a/external_services/proposals_weighted.py
+++ b/external_services/proposals_weighted.py
@@ -1,17 +1,27 @@
 # pages/proposals_weighted.py
 from __future__ import annotations
+
 import streamlit as st
+from external_services.fake_api_weighted import (
+    list_weighted_votes,
+    tally_proposal_weighted,
+    vote_weighted,
+)
+
 
 # try to read proposals from your existing fake_api; fall back to manual ID entry
 def _list_proposals():
     try:
-        from external_services.fake_api import list_proposals  # your existing helper if present
-        return list_proposals()  # expected: list[{"id": int, "title": str, ...}] or similar
+        from external_services.fake_api import (
+            list_proposals,
+        )  # your existing helper if present
+
+        return (
+            list_proposals()
+        )  # expected: list[{"id": int, "title": str, ...}] or similar
     except Exception:
         return []
 
-# weighted api (new add-on)
-from external_services.fake_api_weighted import vote_weighted, tally_proposal_weighted, list_weighted_votes
 
 def render():
     st.title("📑 Proposals (Weighted)")
@@ -19,8 +29,15 @@ def render():
 
     # pick proposal
     if props:
-        labels = [f'#{p.get("id", i)} — {p.get("title","(no title)")} ' for i, p in enumerate(props)]
-        idx = st.selectbox("Choose a proposal", range(len(props)), format_func=lambda i: labels[i])
+        labels = [
+            f'#{p.get("id", i)} — {p.get("title","(no title)")}'
+            for i, p in enumerate(props)
+        ]
+        idx = st.selectbox(
+            "Choose a proposal",
+            range(len(props)),
+            format_func=lambda i: labels[i],
+        )
         pid = int(props[idx].get("id", idx + 1))
         title = props[idx].get("title", f"Proposal {pid}")
     else:
@@ -30,8 +47,8 @@ def render():
 
     st.subheader(title)
 
-    # species / choice
-    species = st.selectbox("I am a…", ["human", "company", "ai"], index=0)
+    # species / choice from global sidebar
+    species = st.session_state["species"]
     c1, c2 = st.columns(2)
     with c1:
         if st.button("👍 Vote UP", use_container_width=True):
@@ -39,23 +56,30 @@ def render():
             st.rerun()
     with c2:
         if st.button("👎 Vote DOWN", use_container_width=True):
-            vote_weighted(pid, st.session_state.get("username", "anon"), "down", species)
+            vote_weighted(
+                pid, st.session_state.get("username", "anon"), "down", species
+            )
             st.rerun()
 
     # live tally
     tally = tally_proposal_weighted(pid)
     up, down, total = tally["up"], tally["down"], tally["total"]
     pct = (up / total * 100) if total > 0 else 0.0
-    st.markdown(f"**Weighted tally:** {up:.3f} ↑ / {down:.3f} ↓ — total {total:.3f}  (**{pct:.1f}% yes**)")
+    st.markdown(
+        f"**Weighted tally:** {up:.3f} ↑ / {down:.3f} ↓ — total {total:.3f}  "
+        f"(**{pct:.1f}% yes**)",
+    )
 
     with st.expander("Breakdown"):
         st.write("Per-voter weights:", tally.get("per_voter_weights", {}))
         st.write("Counts by species:", tally.get("counts", {}))
         st.write("Raw votes:", list_weighted_votes(pid))
 
+
 # Streamlit entry
 def main():
     render()
+
 
 if __name__ == "__main__":
     main()

--- a/pages/proposals_weighted.py
+++ b/pages/proposals_weighted.py
@@ -1,22 +1,24 @@
 # pages/proposals_weighted.py
 from __future__ import annotations
+
 import streamlit as st
+from external_services.fake_api_weighted import (
+    list_weighted_votes,
+    tally_proposal_weighted,
+    vote_weighted,
+)
+
 
 # ---- proposal list (best-effort) --------------------------------------------
 def _list_proposals():
     """Try to pull proposals from your existing fake_api; fallback to none."""
     try:
         from external_services.fake_api import list_proposals  # optional, may not exist
+
         return list_proposals()  # expected: [{"id": int, "title": str, ...}, ...]
     except Exception:
         return []
 
-# ---- weighted API (new add-on you created earlier) --------------------------
-from external_services.fake_api_weighted import (
-    vote_weighted,
-    tally_proposal_weighted,
-    list_weighted_votes,
-)
 
 def render():
     st.title("📑 Proposals (Weighted)")
@@ -38,19 +40,15 @@ def render():
         title = proposals[idx].get("title", f"Proposal {pid}")
     else:
         st.info("No proposals from backend. Enter an ID to test the weighted engine.")
-        pid = st.number_input("Proposal ID", min_value=1, value=1, step=1, key="weighted_pid_input")
+        pid = st.number_input(
+            "Proposal ID", min_value=1, value=1, step=1, key="weighted_pid_input"
+        )
         title = f"Proposal {pid}"
 
     st.subheader(title)
 
-    # Species: default from global sidebar, but let user override here
-    default_species = st.session_state.get("species", "human")
-    species = st.selectbox(
-        "I am a…",
-        ["human", "company", "ai"],
-        index=["human", "company", "ai"].index(default_species),
-        key=f"weighted_species_select_{pid}",
-    )
+    # Use species chosen in the global sidebar
+    species = st.session_state["species"]
 
     col_up, col_down = st.columns(2)
 
@@ -80,7 +78,7 @@ def render():
     pct_yes = (up / total * 100.0) if total > 0 else 0.0
     st.markdown(
         f"**Weighted tally:** {up:.3f} ↑ / {down:.3f} ↓ — total {total:.3f}  "
-        f"(**{pct_yes:.1f}% yes**)"
+        f"(**{pct_yes:.1f}% yes**)",
     )
 
     with st.expander("Breakdown"):
@@ -88,8 +86,10 @@ def render():
         st.write("Counts by species:", tally.get("counts", {}))
         st.write("Raw weighted votes:", list_weighted_votes(pid))
 
+
 def main():
     render()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Read species from sidebar session state in weighted proposal page
- Remove redundant species selector from external services sample

## Testing
- `pre-commit run --files pages/proposals_weighted.py external_services/proposals_weighted.py`

------
https://chatgpt.com/codex/tasks/task_e_68955cbadeec832094d386581d046728