### PR TITLE
Add species weights configuration for voting

### DIFF
--- a/services/weights.py
+++ b/services/weights.py
@@ -1,0 +1,11 @@
+from typing import Dict
+
+w1 = 1/3
+w2 = 1/3
+w3 = 1/3
+
+SPECIES_WEIGHTS: Dict[str, float] = {
+    "human": w1,
+    "company": w2,
+    "ai": w3,
+}

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -4146,6 +4146,8 @@ if __name__ == "__main__":
 from dataclasses import dataclass
 from typing import Literal, Dict, List
 
+from services.weights import SPECIES_WEIGHTS
+
 Species = Literal["human","company","ai"]
 DecisionLevel = Literal["standard","important"]
 THRESHOLDS: Dict[DecisionLevel, float] = {"standard": 0.60, "important": 0.90}
@@ -4168,9 +4170,13 @@ def vote_weighted(proposal_id: int, voter: str, choice: str, species: str="human
 
 def _species_shares(active: List[Species]) -> Dict[Species, float]:
     present = sorted(set(active))
-    if not present: return {}
-    share = 1.0 / len(present)  # ⅓ each if all present; renormalized if not
-    return {s: share for s in present}
+    if not present:
+        return {}
+    weights = {s: SPECIES_WEIGHTS.get(s, 0.0) for s in present}
+    total = sum(weights.values())
+    if total <= 0:
+        return {s: 0.0 for s in present}
+    return {s: weights[s] / total for s in present}
 
 def tally_proposal_weighted(proposal_id: int):
     V = [v for v in _WEIGHTED_VOTES if v.proposal_id == int(proposal_id)]


### PR DESCRIPTION
## Summary
- introduce `SPECIES_WEIGHTS` in new `services/weights.py`
- consult configurable species weights in `voting_engine` and `superNova_2177` tally logic
- replace `agent` species with `ai` in `voting_engine`

## Testing
- `pytest` *(fails: module 'ui' has no attribute '_determine_backend' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68955cb79b748320b626b1f5e193dc5f