### PR TITLE
Expose weighted voting helpers

### DIFF
--- a/docs/INTEGRATION_PLAN.md
+++ b/docs/INTEGRATION_PLAN.md
@@ -1,0 +1,20 @@
+# Integration Plan
+
+## Voting API
+
+The weighted voting engine now exposes a small public API in `superNova_2177`:
+
+- `register_vote(proposal_id, voter, choice, species="human")`
+- `tally_votes(proposal_id)`
+- `get_threshold(level="standard")`
+- `decide(proposal_id, level="standard")`
+
+## UI Adapter
+
+UI components should import the helpers in `services/voting_adapter.py` which wrap the core
+API with UI-friendly names:
+
+- `cast_vote`
+- `tally`
+- `threshold`
+- `finalize`

--- a/services/voting_adapter.py
+++ b/services/voting_adapter.py
@@ -1,0 +1,20 @@
+"""UI-friendly voting helpers."""
+from superNova_2177 import register_vote, tally_votes, get_threshold, decide
+
+def cast_vote(
+    proposal_id: int, voter: str, choice: str, species: str = "human"
+) -> dict:
+    """Wrapper for :func:`register_vote` with a UI-oriented name."""
+    return register_vote(proposal_id, voter, choice, species)
+
+def tally(proposal_id: int) -> dict:
+    """Wrapper for :func:`tally_votes` using a concise alias."""
+    return tally_votes(proposal_id)
+
+def threshold(level: str = "standard") -> float:
+    """Expose :func:`get_threshold` for UI components."""
+    return get_threshold(level)
+
+def finalize(proposal_id: int, level: str = "standard") -> dict:
+    """Wrapper around :func:`decide` for UI readability."""
+    return decide(proposal_id, level)

--- a/superNova_2177.py
+++ b/superNova_2177.py
@@ -4144,7 +4144,7 @@ if __name__ == "__main__":
 
 # === WEIGHTED VOTING ENGINE (auto-added) =====================================
 from dataclasses import dataclass
-from typing import Literal, Dict, List
+from typing import Literal, Dict, List, Any
 
 Species = Literal["human","company","ai"]
 DecisionLevel = Literal["standard","important"]
@@ -4192,4 +4192,26 @@ def decide_weighted_api(proposal_id: int, level: str="standard"):
     status = "accepted" if (t["total"]>0 and (t["up"]/t["total"])>=thr) else "rejected"
     t.update({"proposal_id": int(proposal_id), "status": status, "threshold": thr})
     return t
+
+
+# --- Public wrappers -------------------------------------------------------
+def register_vote(proposal_id: int, voter: str, choice: str, species: str = "human") -> Dict[str, Any]:
+    """Record a vote using the weighted engine."""
+    return vote_weighted(proposal_id, voter, choice, species)
+
+
+def tally_votes(proposal_id: int) -> Dict[str, Any]:
+    """Return the weighted tally for a proposal."""
+    return tally_proposal_weighted(proposal_id)
+
+
+def get_threshold(level: str = "standard") -> float:
+    """Fetch the decision threshold for a given level."""
+    key = "important" if str(level).lower() == "important" else "standard"
+    return THRESHOLDS[key]
+
+
+def decide(proposal_id: int, level: str = "standard") -> Dict[str, Any]:
+    """Evaluate a proposal outcome using the weighted engine."""
+    return decide_weighted_api(proposal_id, level)
 # === END WEIGHTED VOTING ENGINE ==============================================


### PR DESCRIPTION
## Summary
- expose public voting helpers in `superNova_2177`
- add `services.voting_adapter` for UI consumers
- document new API and adapter usage

## Testing
- `pre-commit run --files superNova_2177.py services/voting_adapter.py services/__init__.py docs/INTEGRATION_PLAN.md` *(skipped: black, ruff)*
- `pytest` *(fails: AttributeError module 'ui' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68955cb6dae88320b7875c6bcbc057bc