### PR TITLE
Add weighted voting demo loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ supernova-federate create --creator Alice --config HARMONY_WEIGHT=0.9
 # Cast a vote on a fork
 
 supernova-federate vote <fork_id> --voter Bob --vote yes
+
+# Quick weighted voting demo
+python demos/quick_weighted_demo.py
 ````
 
 The UI listens on [http://localhost:8888](http://localhost:8888) by default.

--- a/demos/quick_weighted_demo.py
+++ b/demos/quick_weighted_demo.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# STRICTLY A SOCIAL MEDIA PLATFORM
+# Intellectual Property & Artistic Inspiration
+# Legal & Ethical Safeguards
+"""Quick demo for loading a weighted proposal.
+
+This script loads proposals from ``weighted_demo.json`` using the
+in-memory adapter so they are available for immediate testing.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import List, Dict
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from external_services.fake_api import create_proposal, list_proposals  # noqa: E402
+
+
+def load_sample_proposals(path: Path) -> List[Dict[str, object]]:
+    """Load proposals from ``path`` and store them via the adapter."""
+    data = json.loads(path.read_text())
+    for p in data.get("proposals", []):
+        create_proposal(p.get("author", "anon"), p.get("title", ""), p.get("body", ""))
+    return list_proposals()
+
+
+def main() -> None:
+    file_path = Path(__file__).with_name("weighted_demo.json")
+    proposals = load_sample_proposals(file_path)
+    print(json.dumps(proposals, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/weighted_demo.json
+++ b/demos/weighted_demo.json
@@ -1,0 +1,9 @@
+{
+  "proposals": [
+    {
+      "author": "alice",
+      "title": "Increase resonance capacity",
+      "body": "Upgrade the harmonic engine to support weighted voting."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- provide sample proposal data for weighted voting demo
- add quick loader script using in-memory adapter
- document quick weighted demo in README

## Testing
- `pre-commit run --files demos/quick_weighted_demo.py demos/weighted_demo.json README.md`
- `pytest` *(fails: module 'ui' has no attribute '_determine_backend', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68955cb2c99c832094e55004e770f2dd