### PR TITLE
refactor: route weighted voting through adapter

### DIFF
--- a/external_services/decisions_weighted.py
+++ b/external_services/decisions_weighted.py
@@ -1,20 +1,27 @@
 # pages/decisions_weighted.py
 from __future__ import annotations
 import streamlit as st
-from external_services.fake_api_weighted import tally_proposal_weighted, decide_weighted_api
+from services import voting_adapter
+
 
 def _list_proposals():
     try:
         from external_services.fake_api import list_proposals
+
         return list_proposals()
     except Exception:
         return []
 
+
 def render():
     st.title("✅ Decisions (Weighted)")
 
-    level = st.selectbox("Decision level", ["standard", "important"], index=0,
-                         help="standard = 60% yes, important = 90% yes (weighted)")
+    level = st.selectbox(
+        "Decision level",
+        ["standard", "important"],
+        index=0,
+        help="standard = 60% yes, important = 90% yes (weighted)",
+    )
     props = _list_proposals()
 
     if props:
@@ -23,28 +30,42 @@ def render():
             title = p.get("title", f"Proposal {pid}")
             st.subheader(f"#{pid} — {title}")
 
-            tally = tally_proposal_weighted(pid)
+            tally = voting_adapter.tally_votes(pid)
             up, down, total = tally["up"], tally["down"], tally["total"]
             pct = (up / total * 100) if total > 0 else 0.0
-            st.markdown(f"**Weighted tally:** {up:.3f} ↑ / {down:.3f} ↓ — total {total:.3f}  (**{pct:.1f}% yes**)")
+            st.markdown(
+                f"**Weighted tally:** {up:.3f} ↑ / {down:.3f} ↓ — total {total:.3f}  "
+                f"(**{pct:.1f}% yes**)"
+            )
 
             if st.button(f"Decide (weighted) #{pid}", key=f"wdec_{pid}"):
-                res = decide_weighted_api(pid, level)
-                st.success(f"Decision: **{res.get('status','?').upper()}** — threshold: {int(res['threshold']*100)}%")
+                res = voting_adapter.decide_vote(pid, level)
+                st.success(
+                    f"Decision: **{res.get('status','?').upper()}** — "
+                    f"threshold: {int(res['threshold']*100)}%"
+                )
             st.divider()
     else:
         st.info("No proposals listed by backend. Enter a Proposal ID to test.")
         pid = st.number_input("Proposal ID", min_value=1, value=1, step=1)
-        tally = tally_proposal_weighted(pid)
+        tally = voting_adapter.tally_votes(pid)
         up, down, total = tally["up"], tally["down"], tally["total"]
         pct = (up / total * 100) if total > 0 else 0.0
-        st.markdown(f"**Weighted tally:** {up:.3f} ↑ / {down:.3f} ↓ — total {total:.3f}  (**{pct:.1f}% yes**)")
+        st.markdown(
+            f"**Weighted tally:** {up:.3f} ↑ / {down:.3f} ↓ — total {total:.3f}  "
+            f"(**{pct:.1f}% yes**)"
+        )
         if st.button("Decide (weighted)"):
-            res = decide_weighted_api(pid, level)
-            st.success(f"Decision: **{res.get('status','?').upper()}** — threshold: {int(res['threshold']*100)}%")
+            res = voting_adapter.decide_vote(pid, level)
+            st.success(
+                f"Decision: **{res.get('status','?').upper()}** — "
+                f"threshold: {int(res['threshold']*100)}%"
+            )
+
 
 def main():
     render()
+
 
 if __name__ == "__main__":
     main()

--- a/external_services/fake_api_weighted.py
+++ b/external_services/fake_api_weighted.py
@@ -1,44 +1,57 @@
-# external_services/fake_api_weighted.py
-# In-memory weighted voting API (humans / companies / ai), built to sit
-# alongside your existing external_services.fake_api without breaking it.
+"""DEPRECATED: use services.voting_adapter instead.
+
+In-memory weighted voting API (humans / companies / ai), built to sit
+alongside your existing external_services.fake_api without breaking it.
+"""
 
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import Dict, List, Literal, Tuple, Any
+from typing import Dict, List, Any
 
 try:
     # Requires voting_engine.py (dataclass Vote + tally/decide)
     from voting_engine import Vote, tally_weighted, decide_weighted
-except Exception as e:  # graceful fallback so imports never crash the app
+except Exception:  # graceful fallback so imports never crash the app
     Vote = None  # type: ignore
     tally_weighted = decide_weighted = None  # type: ignore
 
 # ---- in-memory store for weighted votes -------------------------------------
 
-# Each item: {"proposal_id": int, "voter": str, "choice": "up"/"down", "species": "human"/"company"/"ai"}
+# Each item: {"proposal_id": int, "voter": str, "choice": "up"/"down",
+#             "species": "human"/"company"/"ai"}
 _WEIGHTED_VOTES: List[Dict[str, Any]] = []
 
 _SPECIES = {"human", "company", "ai"}
+
 
 def _norm_species(s: str) -> str:
     s = (s or "").strip().lower()
     if s in _SPECIES:
         return s
     # common aliases
-    if s in {"humans"}: return "human"
-    if s in {"companies", "org", "organization", "corp"}: return "company"
-    if s in {"agent", "agents", "machine", "robot", "model"}: return "ai"
+    if s in {"humans"}:
+        return "human"
+    if s in {"companies", "org", "organization", "corp"}:
+        return "company"
+    if s in {"agent", "agents", "machine", "robot", "model"}:
+        return "ai"
     return "human"
+
 
 def _norm_choice(c: str) -> str:
     c = (c or "").strip().lower()
-    if c in {"up", "yes", "y", "approve", "accept"}: return "up"
-    if c in {"down", "no", "n", "reject"}: return "down"
+    if c in {"up", "yes", "y", "approve", "accept"}:
+        return "up"
+    if c in {"down", "no", "n", "reject"}:
+        return "down"
     return "down"
+
 
 # ---- public API --------------------------------------------------------------
 
-def vote_weighted(proposal_id: int, voter: str, choice: str, species: str = "human") -> Dict[str, Any]:
+
+def vote_weighted(
+    proposal_id: int, voter: str, choice: str, species: str = "human"
+) -> Dict[str, Any]:
     """Record a weighted vote for proposal_id."""
     entry = {
         "proposal_id": int(proposal_id),
@@ -49,11 +62,13 @@ def vote_weighted(proposal_id: int, voter: str, choice: str, species: str = "hum
     _WEIGHTED_VOTES.append(entry)
     return {"ok": True, "stored": entry}
 
+
 def list_weighted_votes(proposal_id: int | None = None) -> List[Dict[str, Any]]:
     if proposal_id is None:
         return list(_WEIGHTED_VOTES)
     pid = int(proposal_id)
     return [v for v in _WEIGHTED_VOTES if v["proposal_id"] == pid]
+
 
 def clear_weighted_votes(proposal_id: int | None = None) -> Dict[str, Any]:
     global _WEIGHTED_VOTES
@@ -66,10 +81,17 @@ def clear_weighted_votes(proposal_id: int | None = None) -> Dict[str, Any]:
     _WEIGHTED_VOTES = kept
     return {"ok": True, "removed": removed, "proposal_id": pid}
 
+
 def tally_proposal_weighted(proposal_id: int) -> Dict[str, Any]:
     """Return weighted up/down/total and a breakdown (per-voter weights & counts)."""
     if Vote is None or tally_weighted is None:
-        return {"up": 0.0, "down": 0.0, "total": 0.0, "per_voter_weights": {}, "counts": {}}
+        return {
+            "up": 0.0,
+            "down": 0.0,
+            "total": 0.0,
+            "per_voter_weights": {},
+            "counts": {},
+        }
     pid = int(proposal_id)
     votes = [Vote(**v) for v in _WEIGHTED_VOTES if v["proposal_id"] == pid]
     up, down, total, per_voter = tally_weighted(votes, pid)
@@ -77,12 +99,26 @@ def tally_proposal_weighted(proposal_id: int) -> Dict[str, Any]:
     counts: Dict[str, int] = {}
     for v in votes:
         counts[v.species] = counts.get(v.species, 0) + 1
-    return {"up": up, "down": down, "total": total, "per_voter_weights": per_voter, "counts": counts}
+    return {
+        "up": up,
+        "down": down,
+        "total": total,
+        "per_voter_weights": per_voter,
+        "counts": counts,
+    }
+
 
 def decide_weighted_api(proposal_id: int, level: str = "standard") -> Dict[str, Any]:
     """Return {'status': 'accepted'|'rejected', 'threshold': float, ...}"""
     if Vote is None or decide_weighted is None:
-        return {"proposal_id": int(proposal_id), "status": "rejected", "threshold": 0.6, "up": 0.0, "down": 0.0, "total": 0.0}
+        return {
+            "proposal_id": int(proposal_id),
+            "status": "rejected",
+            "threshold": 0.6,
+            "up": 0.0,
+            "down": 0.0,
+            "total": 0.0,
+        }
     pid = int(proposal_id)
     votes = [Vote(**v) for v in _WEIGHTED_VOTES if v["proposal_id"] == pid]
     lvl = level if level in {"standard", "important"} else "standard"

--- a/external_services/proposals_weighted.py
+++ b/external_services/proposals_weighted.py
@@ -1,17 +1,22 @@
 # pages/proposals_weighted.py
 from __future__ import annotations
 import streamlit as st
+from services import voting_adapter
+
 
 # try to read proposals from your existing fake_api; fall back to manual ID entry
 def _list_proposals():
     try:
-        from external_services.fake_api import list_proposals  # your existing helper if present
-        return list_proposals()  # expected: list[{"id": int, "title": str, ...}] or similar
+        from external_services.fake_api import (
+            list_proposals,
+        )  # your existing helper if present
+
+        return (
+            list_proposals()
+        )  # expected: list[{"id": int, "title": str, ...}] or similar
     except Exception:
         return []
 
-# weighted api (new add-on)
-from external_services.fake_api_weighted import vote_weighted, tally_proposal_weighted, list_weighted_votes
 
 def render():
     st.title("📑 Proposals (Weighted)")
@@ -19,8 +24,13 @@ def render():
 
     # pick proposal
     if props:
-        labels = [f'#{p.get("id", i)} — {p.get("title","(no title)")} ' for i, p in enumerate(props)]
-        idx = st.selectbox("Choose a proposal", range(len(props)), format_func=lambda i: labels[i])
+        labels = [
+            f'#{p.get("id", i)} — {p.get("title","(no title)")}'
+            for i, p in enumerate(props)
+        ]
+        idx = st.selectbox(
+            "Choose a proposal", range(len(props)), format_func=lambda i: labels[i]
+        )
         pid = int(props[idx].get("id", idx + 1))
         title = props[idx].get("title", f"Proposal {pid}")
     else:
@@ -35,27 +45,36 @@ def render():
     c1, c2 = st.columns(2)
     with c1:
         if st.button("👍 Vote UP", use_container_width=True):
-            vote_weighted(pid, st.session_state.get("username", "anon"), "up", species)
+            voting_adapter.register_vote(
+                pid, st.session_state.get("username", "anon"), "up", species
+            )
             st.rerun()
     with c2:
         if st.button("👎 Vote DOWN", use_container_width=True):
-            vote_weighted(pid, st.session_state.get("username", "anon"), "down", species)
+            voting_adapter.register_vote(
+                pid, st.session_state.get("username", "anon"), "down", species
+            )
             st.rerun()
 
     # live tally
-    tally = tally_proposal_weighted(pid)
+    tally = voting_adapter.tally_votes(pid)
     up, down, total = tally["up"], tally["down"], tally["total"]
     pct = (up / total * 100) if total > 0 else 0.0
-    st.markdown(f"**Weighted tally:** {up:.3f} ↑ / {down:.3f} ↓ — total {total:.3f}  (**{pct:.1f}% yes**)")
+    st.markdown(
+        f"**Weighted tally:** {up:.3f} ↑ / {down:.3f} ↓ — total {total:.3f}  "
+        f"(**{pct:.1f}% yes**)"
+    )
 
     with st.expander("Breakdown"):
         st.write("Per-voter weights:", tally.get("per_voter_weights", {}))
         st.write("Counts by species:", tally.get("counts", {}))
-        st.write("Raw votes:", list_weighted_votes(pid))
+        st.write("Raw votes:", voting_adapter.list_votes(pid))
+
 
 # Streamlit entry
 def main():
     render()
+
 
 if __name__ == "__main__":
     main()

--- a/pages/proposals.py
+++ b/pages/proposals.py
@@ -1,85 +1,135 @@
-import os, json, urllib.request
+import os
+import json
+import urllib.request
 import streamlit as st
 from typing import Dict, Any
+from services import voting_adapter
+
 
 def _use_backend() -> bool:
-    return os.getenv("USE_REAL_BACKEND", "0").lower() in {"1","true","yes"}
+    return os.getenv("USE_REAL_BACKEND", "0").lower() in {"1", "true", "yes"}
+
 
 def _burl() -> str:
-    return os.getenv("BACKEND_URL","http://127.0.0.1:8000")
+    return os.getenv("BACKEND_URL", "http://127.0.0.1:8000")
+
 
 def _get(path: str):
-    with urllib.request.urlopen(_burl()+path) as r:
+    with urllib.request.urlopen(_burl() + path) as r:
         return json.loads(r.read().decode("utf-8"))
+
 
 def _post(path: str, payload: Dict[str, Any]):
     data = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(_burl()+path, data=data, headers={"Content-Type":"application/json"})
+    req = urllib.request.Request(
+        _burl() + path, data=data, headers={"Content-Type": "application/json"}
+    )
     with urllib.request.urlopen(req) as r:
         return json.loads(r.read().decode("utf-8"))
 
+
 # local fallback
 try:
-    from external_services.fake_api import list_proposals, create_proposal, vote, tally_proposal
+    from external_services.fake_api import (
+        list_proposals,
+        create_proposal,
+        vote,
+        tally_proposal,
+    )
 except Exception:
-    def list_proposals(): return []
-    def create_proposal(author,title,body): return {}
-    def vote(pid,voter,choice): return {"ok":False}
-    def tally_proposal(pid): return {"up":0,"down":0}
+
+    def list_proposals():
+        return []
+
+    def create_proposal(author, title, body):
+        return {}
+
+    def vote(pid, voter, choice):
+        return {"ok": False}
+
+    def tally_proposal(pid):
+        return {"up": 0, "down": 0}
+
 
 def main():
     st.subheader("Proposals")
     with st.form("new_proposal"):
         title = st.text_input("Title")
-        body  = st.text_area("Description", height=120)
+        body = st.text_area("Description", height=120)
         submitted = st.form_submit_button("Create")
     if submitted and title.strip():
         if _use_backend():
-            _post("/proposals", {"title":title, "body":body, "author":"guest"})
+            _post("/proposals", {"title": title, "body": body, "author": "guest"})
         else:
             create_proposal("guest", title, body)
-        st.success("Created"); st.rerun()
+        st.success("Created")
+        st.rerun()
 
     # list
     items = _get("/proposals") if _use_backend() else list_proposals()
     for p in items:
         with st.container():
             st.markdown(f"### {p['title']}")
-            st.write(p.get("body",""))
+            st.write(p.get("body", ""))
             pid = p["id"]
             col1, col2, col3 = st.columns(3)
             if col1.button(f"👍 Upvote #{pid}", key=f"u_{pid}"):
-                (_post("/votes", {"proposal_id":pid,"voter":"guest","choice":"up"})
-                 if _use_backend() else vote(pid, "guest", "up"))
+                (
+                    _post(
+                        "/votes", {"proposal_id": pid, "voter": "guest", "choice": "up"}
+                    )
+                    if _use_backend()
+                    else vote(pid, "guest", "up")
+                )
                 st.rerun()
             if col2.button(f"👎 Downvote #{pid}", key=f"d_{pid}"):
-                (_post("/votes", {"proposal_id":pid,"voter":"guest","choice":"down"})
-                 if _use_backend() else vote(pid, "guest", "down"))
+                (
+                    _post(
+                        "/votes",
+                        {"proposal_id": pid, "voter": "guest", "choice": "down"},
+                    )
+                    if _use_backend()
+                    else vote(pid, "guest", "down")
+                )
                 st.rerun()
-            tally = (_get(f"/proposals/{pid}/tally") if _use_backend() else tally_proposal(pid))
+            tally = (
+                _get(f"/proposals/{pid}/tally")
+                if _use_backend()
+                else tally_proposal(pid)
+            )
             col3.metric("Votes", f"{tally.get('up',0)} 👍 / {tally.get('down',0)} 👎")
 
-def render(): main()
+
+def render():
+    main()
+
 
 # --- WEIGHTED VOTING PANEL (auto-added) --------------------------------------
-try:
-    from superNova_2177 import vote_weighted, tally_proposal_weighted  # engine lives here
-except Exception:  # fallback if renamed
-    from supernova_2177 import vote_weighted, tally_proposal_weighted  # type: ignore
+
 
 def _weighted_panel_for_proposal(pid: int):
     import streamlit as st
+
     species = st.session_state.get("species", "human")
     c1, c2 = st.columns(2)
     with c1:
         if st.button(f"👍 Vote UP (weighted) #{pid}", key=f"wup_{pid}"):
-            vote_weighted(pid, st.session_state.get('username','anon'), 'up', species)
+            voting_adapter.register_vote(
+                pid, st.session_state.get("username", "anon"), "up", species
+            )
             st.rerun()
     with c2:
         if st.button(f"👎 Vote DOWN (weighted) #{pid}", key=f"wdown_{pid}"):
-            vote_weighted(pid, st.session_state.get('username','anon'), 'down', species)
+            voting_adapter.register_vote(
+                pid, st.session_state.get("username", "anon"), "down", species
+            )
             st.rerun()
-    t = tally_proposal_weighted(pid)
-    pct = (t['up']/t['total']*100) if t['total'] else 0.0
-    st.caption(f"Weighted: {t['up']:.3f} ↑ / {t['down']:.3f} ↓ — total {t['total']:.3f}  ({pct:.1f}% yes)")
+    t = voting_adapter.tally_votes(pid)
+    pct = (t["up"] / t["total"] * 100) if t["total"] else 0.0
+    st.caption(
+        f"Weighted: {t['up']:.3f} ↑ / {t['down']:.3f} ↓ — total {t['total']:.3f}  "
+        f"({pct:.1f}% yes)"
+    )
+
+
 # --- END WEIGHTED VOTING PANEL -----------------------------------------------

--- a/pages/proposals_weighted.py
+++ b/pages/proposals_weighted.py
@@ -1,22 +1,22 @@
 # pages/proposals_weighted.py
 from __future__ import annotations
 import streamlit as st
+from services import voting_adapter
+
 
 # ---- proposal list (best-effort) --------------------------------------------
 def _list_proposals():
     """Try to pull proposals from your existing fake_api; fallback to none."""
     try:
         from external_services.fake_api import list_proposals  # optional, may not exist
+
         return list_proposals()  # expected: [{"id": int, "title": str, ...}, ...]
     except Exception:
         return []
 
+
 # ---- weighted API (new add-on you created earlier) --------------------------
-from external_services.fake_api_weighted import (
-    vote_weighted,
-    tally_proposal_weighted,
-    list_weighted_votes,
-)
+
 
 def render():
     st.title("📑 Proposals (Weighted)")
@@ -38,7 +38,9 @@ def render():
         title = proposals[idx].get("title", f"Proposal {pid}")
     else:
         st.info("No proposals from backend. Enter an ID to test the weighted engine.")
-        pid = st.number_input("Proposal ID", min_value=1, value=1, step=1, key="weighted_pid_input")
+        pid = st.number_input(
+            "Proposal ID", min_value=1, value=1, step=1, key="weighted_pid_input"
+        )
         title = f"Proposal {pid}"
 
     st.subheader(title)
@@ -56,7 +58,7 @@ def render():
 
     with col_up:
         if st.button("👍 Vote UP", use_container_width=True, key=f"vote_up_{pid}"):
-            vote_weighted(
+            voting_adapter.register_vote(
                 pid,
                 st.session_state.get("username", "anon"),
                 "up",
@@ -66,7 +68,7 @@ def render():
 
     with col_down:
         if st.button("👎 Vote DOWN", use_container_width=True, key=f"vote_down_{pid}"):
-            vote_weighted(
+            voting_adapter.register_vote(
                 pid,
                 st.session_state.get("username", "anon"),
                 "down",
@@ -75,7 +77,7 @@ def render():
             st.rerun()
 
     # Live weighted tally
-    tally = tally_proposal_weighted(pid)
+    tally = voting_adapter.tally_votes(pid)
     up, down, total = tally["up"], tally["down"], tally["total"]
     pct_yes = (up / total * 100.0) if total > 0 else 0.0
     st.markdown(
@@ -86,10 +88,12 @@ def render():
     with st.expander("Breakdown"):
         st.write("Per-voter weights:", tally.get("per_voter_weights", {}))
         st.write("Counts by species:", tally.get("counts", {}))
-        st.write("Raw weighted votes:", list_weighted_votes(pid))
+        st.write("Raw weighted votes:", voting_adapter.list_votes(pid))
+
 
 def main():
     render()
+
 
 if __name__ == "__main__":
     main()

--- a/services/voting_adapter.py
+++ b/services/voting_adapter.py
@@ -1,0 +1,80 @@
+"""Adapters for weighted voting interactions.
+
+This module wraps the underlying weighted voting implementation and
+provides a stable interface for the UI. It prefers the real backend
+available in ``superNova_2177`` but falls back to the in-memory
+``external_services.fake_api_weighted`` module when the backend is
+missing.  Use :func:`register_vote`, :func:`tally_votes`,
+:func:`decide_vote`, and :func:`list_votes` rather than importing
+backend helpers directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+# Attempt to import the real weighted voting functions; otherwise fallback
+try:  # pragma: no cover - best effort import
+    from superNova_2177 import (
+        vote_weighted as _register_vote,
+        tally_proposal_weighted as _tally_votes,
+        decide_weighted_api as _decide_vote,
+        list_weighted_votes as _list_votes,
+    )
+except Exception:  # noqa: BLE001 - fall back gracefully
+    try:  # pragma: no cover
+        from external_services.fake_api_weighted import (
+            vote_weighted as _register_vote,
+            tally_proposal_weighted as _tally_votes,
+            decide_weighted_api as _decide_vote,
+            list_weighted_votes as _list_votes,
+        )
+    except Exception:  # pragma: no cover
+        # Final safety net: provide stub implementations so callers do not crash
+        def _register_vote(*_: Any, **__: Any) -> Dict[str, Any]:
+            return {"ok": False}
+
+        def _tally_votes(*_: Any, **__: Any) -> Dict[str, Any]:
+            return {"up": 0.0, "down": 0.0, "total": 0.0}
+
+        def _decide_vote(*_: Any, **__: Any) -> Dict[str, Any]:
+            return {
+                "proposal_id": 0,
+                "status": "rejected",
+                "threshold": 0.6,
+                "up": 0.0,
+                "down": 0.0,
+                "total": 0.0,
+            }
+
+        def _list_votes(*_: Any, **__: Any) -> List[Dict[str, Any]]:
+            return []
+
+
+def register_vote(
+    proposal_id: int,
+    voter: str,
+    choice: str,
+    species: str = "human",
+) -> Dict[str, Any]:
+    """Record a weighted vote via the configured backend."""
+
+    return _register_vote(proposal_id, voter, choice, species)
+
+
+def tally_votes(proposal_id: int) -> Dict[str, Any]:
+    """Return the weighted tally for ``proposal_id``."""
+
+    return _tally_votes(proposal_id)
+
+
+def decide_vote(proposal_id: int, level: str = "standard") -> Dict[str, Any]:
+    """Compute a decision for ``proposal_id`` at the given ``level``."""
+
+    return _decide_vote(proposal_id, level)
+
+
+def list_votes(proposal_id: int | None = None) -> List[Dict[str, Any]]:
+    """List raw weighted votes, optionally filtered by ``proposal_id``."""
+
+    return _list_votes(proposal_id)


### PR DESCRIPTION
## Summary
- add services.voting_adapter to abstract weighted voting calls
- switch UI and external service helpers to use voting_adapter
- deprecate external_services.fake_api_weighted in favor of the adapter

## Testing
- `pre-commit run --files external_services/decisions_weighted.py external_services/fake_api_weighted.py external_services/proposals_weighted.py integrate_weighted.py pages/decisions.py pages/proposals.py pages/proposals_weighted.py services/voting_adapter.py services/__init__.py`
- `pytest` *(fails: AttributeError module 'ui' has no attribute '_determine_backend'; AttributeError module 'ui_adapters' has no attribute 'search_users'; AssertionError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68955caa7f208320a648e47bb5444a32