### PR TITLE
Add harmonizer adapter with backend toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,10 @@ python superNova_2177.py
 The Streamlit page expects this backend by default. If you run it elsewhere, set
 the `BACKEND_URL` environment variable so the UI can find the API.
 
+Set `USE_REAL_BACKEND=1` to route harmonizer services to the live API. When
+unset, in-memory stubs are used for local demos. `BACKEND_URL` specifies the
+server address (default `http://localhost:8000`).
+
 ### Troubleshooting the UI
 
 - **Missing dependencies**: If the interface fails with `ModuleNotFoundError`, run

--- a/services/harmonizer_adapter.py
+++ b/services/harmonizer_adapter.py
@@ -1,0 +1,77 @@
+"""Harmonizer-related backend helpers.
+
+Environment variables:
+    USE_REAL_BACKEND: set to "1" to contact the live API. The default
+        uses in-memory stubs suitable for local demos.
+    BACKEND_URL: base URL for the backend API (default ``http://localhost:8000``).
+
+All functions return dictionaries and attempt to fail gracefully if the
+backend is unreachable or returns an error.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+import requests
+
+USE_REAL_BACKEND = os.getenv("USE_REAL_BACKEND", "0") == "1"
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+
+# simple in-memory store for stubbed mode
+_stub_users: List[Dict[str, Any]] = []
+
+
+def register(username: str, email: str, password: str) -> Dict[str, Any]:
+    """Register a harmonizer via the backend or a local stub."""
+    if not USE_REAL_BACKEND:
+        if any(u["username"] == username or u["email"] == email for u in _stub_users):
+            return {"error": "Username or email already exists"}
+        user = {"username": username, "email": email, "influence_score": 0.0}
+        _stub_users.append(user)
+        return user
+    try:
+        resp = requests.post(
+            f"{BACKEND_URL}/users/register",
+            json={"username": username, "email": email, "password": password},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - network failures
+        return {"error": str(exc)}
+
+
+def get_influence_score(username: str) -> Dict[str, Any]:
+    """Return a harmonizer's influence score."""
+    if not USE_REAL_BACKEND:
+        user = next((u for u in _stub_users if u["username"] == username), None)
+        if not user:
+            return {"error": "Harmonizer not found"}
+        return {"influence_score": user.get("influence_score", 0.0)}
+    try:
+        resp = requests.get(f"{BACKEND_URL}/users/{username}", timeout=5)
+        resp.raise_for_status()
+        data = resp.json()
+        return {"influence_score": data.get("network_centrality", 0.0)}
+    except Exception as exc:  # pragma: no cover - network failures
+        return {"error": str(exc)}
+
+
+def list_harmonizers(limit: int = 10) -> Dict[str, Any]:
+    """List harmonizers with an optional limit."""
+    if not USE_REAL_BACKEND:
+        return {"harmonizers": _stub_users[:limit]}
+    try:
+        resp = requests.get(f"{BACKEND_URL}/users/search", params={"q": ""}, timeout=5)
+        resp.raise_for_status()
+        users = resp.json()
+        return {"harmonizers": users[:limit]}
+    except Exception as exc:  # pragma: no cover - network failures
+        return {"error": str(exc)}
+
+
+def reset_stub() -> None:
+    """Clear stubbed users (testing helper)."""
+    _stub_users.clear()

--- a/tests/test_harmonizer_adapter.py
+++ b/tests/test_harmonizer_adapter.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+import importlib
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+
+def test_stub_harmonizer_functions(monkeypatch):
+    monkeypatch.setenv("USE_REAL_BACKEND", "0")
+    from services import harmonizer_adapter
+
+    importlib.reload(harmonizer_adapter)
+    harmonizer_adapter.reset_stub()
+
+    user = harmonizer_adapter.register("alice", "a@example.com", "pw")
+    assert user["username"] == "alice"
+
+    dup = harmonizer_adapter.register("alice", "b@example.com", "pw")
+    assert "error" in dup
+
+    score = harmonizer_adapter.get_influence_score("alice")
+    assert score["influence_score"] == 0.0
+
+    listing = harmonizer_adapter.list_harmonizers()
+    assert any(u["username"] == "alice" for u in listing["harmonizers"])


### PR DESCRIPTION
## Summary
- add `services/harmonizer_adapter` with register, list, and influence helpers
- document `USE_REAL_BACKEND` and `BACKEND_URL` in README
- cover stub behaviour with tests

## Testing
- `pre-commit run --files services/harmonizer_adapter.py README.md tests/test_harmonizer_adapter.py`
- `pytest` *(fails: AttributeError: module 'ui' has no attribute '_determine_backend')*

------
https://chatgpt.com/codex/tasks/task_e_689569083628832081f80ec2ba68685c