### PR TITLE
Add backend-aware service adapters

### DIFF
--- a/services/harmonizer_adapter.py
+++ b/services/harmonizer_adapter.py
@@ -1,0 +1,63 @@
+"""Text harmonization utilities.
+
+Provides a safe wrapper around potential backend harmonization
+capabilities, exposing a simple :func:`harmonize` function for the UI.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import requests
+
+USE_REAL_BACKEND = os.getenv("USE_REAL_BACKEND", "0").lower() in {"1", "true", "yes"}
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+
+try:  # pragma: no cover - optional import
+    import superNova_2177 as sn_mod  # type: ignore
+except Exception:  # pragma: no cover
+    sn_mod = None
+
+
+def harmonize(
+    text: str, mode: str = "balanced", intensity: float = 0.5
+) -> Dict[str, Any]:
+    """Return a harmonized representation of ``text``.
+
+    Parameters
+    ----------
+    text:
+        The source content to be harmonized.
+    mode:
+        Backend-defined mode, defaulting to ``"balanced"``.
+    intensity:
+        Float value indicating the strength of harmonization.
+    """
+
+    if USE_REAL_BACKEND:
+        if sn_mod and hasattr(sn_mod, "harmonize"):
+            try:
+                result = getattr(sn_mod, "harmonize")(
+                    text, mode=mode, intensity=intensity
+                )
+                return {"available": True, "result": result}
+            except Exception as exc:  # pragma: no cover - backend failure
+                return {"available": False, "error": str(exc)}
+        try:  # pragma: no cover - network path not exercised in tests
+            resp = requests.post(
+                f"{BACKEND_URL}/harmonize",
+                json={"text": text, "mode": mode, "intensity": intensity},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            data.setdefault("available", True)
+            return data
+        except Exception as exc:  # pragma: no cover
+            return {"available": False, "error": str(exc)}
+
+    # Stub fallback simply echoes the text
+    return {"available": False, "result": text}
+
+
+__all__ = ["harmonize"]

--- a/services/karma_adapter.py
+++ b/services/karma_adapter.py
@@ -1,0 +1,87 @@
+"""Karma utilities for UI components.
+
+This module wraps backend karma operations while providing safe
+fallbacks when the backend or underlying functions are unavailable.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import requests
+
+USE_REAL_BACKEND = os.getenv("USE_REAL_BACKEND", "0").lower() in {"1", "true", "yes"}
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+
+try:  # pragma: no cover - optional import
+    import superNova_2177 as sn_mod  # type: ignore
+except Exception:  # pragma: no cover - import may fail
+    sn_mod = None
+
+_stub_karma: Dict[str, float] = {}
+
+
+def get_profile_karma(user: str) -> Dict[str, Any]:
+    """Return karma information for ``user``.
+
+    The function attempts to call a real backend implementation when
+    ``USE_REAL_BACKEND`` is enabled.  If the backend is unavailable or the
+    implementation is missing, a stub response is returned with
+    ``available`` set to ``False``.
+    """
+
+    if USE_REAL_BACKEND:
+        if sn_mod and hasattr(sn_mod, "get_profile_karma"):
+            try:
+                karma = getattr(sn_mod, "get_profile_karma")(user)
+                return {"available": True, "karma": karma}
+            except Exception as exc:  # pragma: no cover - backend failure
+                return {"available": False, "error": str(exc)}
+        try:  # pragma: no cover - network path not exercised in tests
+            resp = requests.get(f"{BACKEND_URL}/karma/{user}", timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            data.setdefault("available", True)
+            return data
+        except Exception as exc:  # pragma: no cover - network errors
+            return {"available": False, "error": str(exc)}
+
+    # Fallback stub mode
+    return {"available": False, "karma": _stub_karma.get(user, 0.0)}
+
+
+def adjust_karma(user: str, delta: float) -> Dict[str, Any]:
+    """Adjust ``user``'s karma by ``delta``.
+
+    Returns a dict containing ``available`` and the updated ``karma``.
+    ``available`` is ``False`` when operating in stub mode or upon backend
+    errors.
+    """
+
+    if USE_REAL_BACKEND:
+        if sn_mod and hasattr(sn_mod, "adjust_karma"):
+            try:
+                karma = getattr(sn_mod, "adjust_karma")(user, delta)
+                return {"available": True, "karma": karma}
+            except Exception as exc:  # pragma: no cover - backend failure
+                return {"available": False, "error": str(exc)}
+        try:  # pragma: no cover - network path not exercised in tests
+            resp = requests.post(
+                f"{BACKEND_URL}/karma/{user}/adjust",
+                json={"delta": delta},
+                timeout=5,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            data.setdefault("available", True)
+            return data
+        except Exception as exc:  # pragma: no cover
+            return {"available": False, "error": str(exc)}
+
+    # Stub fallback
+    new_val = _stub_karma.get(user, 0.0) + float(delta)
+    _stub_karma[user] = new_val
+    return {"available": False, "karma": new_val}
+
+
+__all__ = ["get_profile_karma", "adjust_karma"]

--- a/services/validators_adapter.py
+++ b/services/validators_adapter.py
@@ -1,0 +1,60 @@
+"""Validation helpers for UI components.
+
+The :func:`run_validations` function analyzes a payload using the real
+validation pipeline when available.  In stub mode it reports the backend
+as unavailable.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import requests
+
+USE_REAL_BACKEND = os.getenv("USE_REAL_BACKEND", "0").lower() in {"1", "true", "yes"}
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+
+try:  # pragma: no cover - optional import
+    import superNova_2177 as sn_mod  # type: ignore
+except Exception:  # pragma: no cover
+    sn_mod = None
+
+
+def run_validations(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Run validation integrity analysis on ``payload``.
+
+    Parameters
+    ----------
+    payload:
+        Arbitrary data structure expected by the backend validation
+        pipeline.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary containing ``available`` (bool), ``passed`` (bool), and
+        ``details`` with backend response or error message.
+    """
+
+    if USE_REAL_BACKEND:
+        if sn_mod and hasattr(sn_mod, "analyze_validation_integrity"):
+            try:
+                result = getattr(sn_mod, "analyze_validation_integrity")(payload)
+                passed = bool(result.get("passed") or result.get("valid"))
+                return {"available": True, "passed": passed, "details": result}
+            except Exception as exc:  # pragma: no cover - backend failure
+                return {"available": False, "passed": False, "details": str(exc)}
+        try:  # pragma: no cover - network path not exercised in tests
+            resp = requests.post(f"{BACKEND_URL}/validate", json=payload, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            passed = bool(data.get("passed") or data.get("valid"))
+            return {"available": True, "passed": passed, "details": data}
+        except Exception as exc:  # pragma: no cover
+            return {"available": False, "passed": False, "details": str(exc)}
+
+    # Stub fallback
+    return {"available": False, "passed": False, "details": "backend disabled"}
+
+
+__all__ = ["run_validations"]


### PR DESCRIPTION
## Summary
- add karma adapter with safe fallback and in-memory stub
- add harmonizer adapter for text harmonization with backend checks
- add validators adapter that analyzes payloads or returns stubbed results

## Testing
- `pre-commit run --files services/karma_adapter.py services/harmonizer_adapter.py services/validators_adapter.py`
- `pytest` *(fails: AttributeError in ui modules)*

------
https://chatgpt.com/codex/tasks/task_e_6895695fdc008320b939806f4776a383