### PR TITLE
Graceful adapter fallbacks and centralized API key retrieval

### DIFF
--- a/external_services/llm_client.py
+++ b/external_services/llm_client.py
@@ -7,6 +7,7 @@ import os
 
 import httpx
 
+from utils.api_keys import get_api_key
 from .base_client import BaseClient
 
 
@@ -17,7 +18,7 @@ class LLMClient(BaseClient):
         url = api_url or os.getenv(
             "LLM_API_URL", "https://your-llm-endpoint.com/generate"
         )
-        key = api_key or os.getenv("LLM_API_KEY", "")
+        key = api_key or get_api_key("LLM_API_KEY")
         super().__init__(url, key)
 
     def get_prompt_template(self) -> str:

--- a/external_services/video_client.py
+++ b/external_services/video_client.py
@@ -6,6 +6,7 @@ import os
 
 import httpx
 
+from utils.api_keys import get_api_key
 from .base_client import BaseClient
 
 
@@ -14,7 +15,7 @@ class VideoClient(BaseClient):
 
     def __init__(self, api_url: str | None = None, api_key: str | None = None) -> None:
         url = api_url or os.getenv("VIDEO_API_URL", "")
-        key = api_key or os.getenv("VIDEO_API_KEY", "")
+        key = api_key or get_api_key("VIDEO_API_KEY")
         super().__init__(url, key)
 
     async def generate_video_preview(self, prompt: str) -> dict:

--- a/external_services/vision_client.py
+++ b/external_services/vision_client.py
@@ -7,6 +7,7 @@ import os
 
 import httpx
 
+from utils.api_keys import get_api_key
 from .base_client import BaseClient
 
 
@@ -15,7 +16,7 @@ class VisionClient(BaseClient):
 
     def __init__(self, api_url: str | None = None, api_key: str | None = None) -> None:
         url = api_url or os.getenv("VISION_API_URL", "")
-        key = api_key or os.getenv("VISION_API_KEY", "")
+        key = api_key or get_api_key("VISION_API_KEY")
         super().__init__(url, key)
 
     async def analyze_timeline(self, video_url: str) -> dict:

--- a/llm_backends.py
+++ b/llm_backends.py
@@ -7,6 +7,8 @@ try:  # Optional streamlit import for reading secrets during runtime
 except Exception:  # pragma: no cover - not available outside Streamlit
     st = None
 
+from utils.api_keys import get_api_key
+
 
 def dummy_backend(prompt: str, api_key: str | None = None) -> str:
     """Return a canned response for testing."""
@@ -16,7 +18,7 @@ def dummy_backend(prompt: str, api_key: str | None = None) -> str:
 def gpt4o_backend(prompt: str, api_key: str | None = None) -> str:
     """Call OpenAI GPT-4o and return the response text."""
     if api_key is None:
-        api_key = os.getenv("OPENAI_API_KEY", "")
+        api_key = get_api_key("OPENAI_API_KEY")
     if not api_key:
         raise ValueError("OPENAI_API_KEY required for GPT-4o backend")
     url = "https://api.openai.com/v1/chat/completions"
@@ -30,7 +32,7 @@ def gpt4o_backend(prompt: str, api_key: str | None = None) -> str:
 def claude3_backend(prompt: str, api_key: str | None = None) -> str:
     """Call Anthropic Claude-3 and return the response text."""
     if api_key is None:
-        api_key = os.getenv("ANTHROPIC_API_KEY", "")
+        api_key = get_api_key("ANTHROPIC_API_KEY")
     if not api_key:
         raise ValueError("ANTHROPIC_API_KEY required for Claude-3 backend")
     url = "https://api.anthropic.com/v1/messages"
@@ -47,7 +49,7 @@ def claude3_backend(prompt: str, api_key: str | None = None) -> str:
 def _gemini_backend(prompt: str, api_key: str | None = None) -> str:
     """Call Google Gemini and return the response text."""
     if api_key is None:
-        api_key = os.getenv("GOOGLE_API_KEY", "")
+        api_key = get_api_key("GOOGLE_API_KEY")
     if not api_key:
         raise ValueError("GOOGLE_API_KEY required for Gemini backend")
     url = (
@@ -67,9 +69,7 @@ def default_gpt_backend(api_key: str | None = None) -> Callable[[str], str]:
     """Factory for OpenAI's GPT backend using ``gpt-3.5-turbo``."""
 
     if api_key is None:
-        api_key = os.getenv("OPENAI_API_KEY")
-        if not api_key and st is not None:
-            api_key = st.secrets.get("OPENAI_API_KEY", "")
+        api_key = get_api_key("OPENAI_API_KEY")
 
     def call(prompt: str) -> str:
         if not api_key:
@@ -91,9 +91,7 @@ def claude_backend(api_key: str | None = None) -> Callable[[str], str]:
     """Factory for Anthropic Claude backend."""
 
     if api_key is None:
-        api_key = os.getenv("ANTHROPIC_API_KEY")
-        if not api_key and st is not None:
-            api_key = st.secrets.get("ANTHROPIC_API_KEY", "")
+        api_key = get_api_key("ANTHROPIC_API_KEY")
 
     def call(prompt: str) -> str:
         if not api_key:
@@ -115,9 +113,7 @@ def gemini_backend(api_key: str | None = None) -> Callable[[str], str]:
     """Factory for Google Gemini backend."""
 
     if api_key is None:
-        api_key = os.getenv("GOOGLE_API_KEY")
-        if not api_key and st is not None:
-            api_key = st.secrets.get("GOOGLE_API_KEY", "")
+        api_key = get_api_key("GOOGLE_API_KEY")
 
     def call(prompt: str) -> str:
         if not api_key:

--- a/pages/settings.py
+++ b/pages/settings.py
@@ -14,8 +14,8 @@ def main() -> None:
         "Customize your experience here. (Placeholder – more options coming soon!)"
     )
 
-    # Backend toggle stored in session state for adapter access
-    st.toggle("Enable backend", key="use_backend")
+    # Backend toggle stored in local variable
+    use_backend = st.toggle("Enable backend", key="settings_use_backend")
 
     with st.form("profile_form"):
         bio = st.text_area("Bio", max_chars=280)
@@ -24,14 +24,17 @@ def main() -> None:
 
     if submitted:
         prefs = [p.strip() for p in prefs_raw.split(",") if p.strip()]
-        result = update_profile_adapter(bio, prefs)
-        status = result.get("status")
-        if status == "ok":
-            st.success("Profile updated successfully")
-        elif status == "stubbed":
-            st.info("Profile updated (stub)")
+        result = update_profile_adapter(bio, prefs, use_backend=use_backend)
+        if not result.get("available", True):
+            st.warning("Profile service unavailable.")
         else:
-            st.error(f"Update failed: {result.get('error', 'unknown error')}")
+            status = result.get("status")
+            if status == "ok":
+                st.success("Profile updated successfully")
+            elif status == "stubbed":
+                st.info("Profile updated (stub)")
+            else:
+                st.error(f"Update failed: {result.get('error', 'unknown error')}")
 
 
 if __name__ == "__main__":

--- a/pages/system_status.py
+++ b/pages/system_status.py
@@ -13,14 +13,14 @@ from system_status_adapter import get_status
 def main() -> None:
     """Render system status metrics using Streamlit widgets."""
     use_backend = st.toggle("Enable backend", value=True, key="sys_status_toggle")
-    data = get_status() if use_backend else None
-    if not data or "metrics" not in data:
-        st.info("Backend disabled or unavailable.")
+    data = get_status() if use_backend else {"available": False}
+    if not data.get("available") or "metrics" not in data:
+        st.warning("Backend disabled or unavailable.")
         st.metric("Harmonizers", "N/A")
         st.metric("VibeNodes", "N/A")
         st.metric("Entropy", "N/A")
     else:
-        metrics = data["metrics"]
+        metrics = data.get("metrics", {})
         st.metric("Harmonizers", metrics.get("total_harmonizers", 0))
         st.metric("VibeNodes", metrics.get("total_vibenodes", 0))
         st.metric("Entropy", metrics.get("current_system_entropy", 0))

--- a/profile_adapter.py
+++ b/profile_adapter.py
@@ -5,34 +5,55 @@ from __future__ import annotations
 import os
 from typing import Dict, List
 
-import requests
-import streamlit as st
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - requests not installed
+    requests = None  # type: ignore
+
+try:  # pragma: no cover - streamlit may be missing in tests
+    import streamlit as st
+except Exception:  # pragma: no cover
+    st = None  # type: ignore
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 
 
-def update_profile_adapter(bio: str, cultural_preferences: List[str]) -> Dict[str, str]:
+def update_profile_adapter(
+    bio: str,
+    cultural_preferences: List[str],
+    *,
+    use_backend: bool | None = None,
+) -> Dict[str, str | bool]:
     """Update the user's profile.
 
-    Checks the ``use_backend`` toggle in ``st.session_state``. When disabled,
-    returns a stubbed response. When enabled, it attempts to call the backend's
-    ``update_profile`` endpoint and captures errors.
+    Always returns a dictionary containing an ``available`` flag.
     """
 
     if not bio.strip():
-        return {"status": "error", "error": "Bio is required"}
+        return {"available": True, "status": "error", "error": "Bio is required"}
 
-    if not st.session_state.get("use_backend", False):
+    if use_backend is None and st is not None:
+        use_backend = st.session_state.get("use_backend", False)
+
+    if not use_backend:
         return {
+            "available": True,
             "status": "stubbed",
             "bio": bio,
             "cultural_preferences": cultural_preferences,
+        }
+
+    if requests is None:
+        return {
+            "available": False,
+            "status": "error",
+            "error": "requests not installed",
         }
 
     payload = {"bio": bio, "cultural_preferences": cultural_preferences}
     try:
         resp = requests.put(f"{BACKEND_URL}/users/me", json=payload, timeout=5)
         resp.raise_for_status()
+        return {"available": True, "status": "ok"}
     except Exception as exc:
-        return {"status": "error", "error": str(exc)}
-    return {"status": "ok"}
+        return {"available": False, "status": "error", "error": str(exc)}

--- a/system_status_adapter.py
+++ b/system_status_adapter.py
@@ -6,24 +6,29 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-import requests
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - requests missing
+    requests = None  # type: ignore
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 OFFLINE_MODE = os.getenv("OFFLINE_MODE", "0") == "1"
 
 
-def get_status() -> Optional[Dict[str, Any]]:
+def get_status() -> Dict[str, Any]:
     """Fetch system status data from the backend API.
 
-    Returns ``None`` if offline mode is enabled or the request fails.
+    Always returns a dictionary containing ``available``.
     """
-    if OFFLINE_MODE:
-        return None
+    if OFFLINE_MODE or requests is None:
+        return {"available": False}
     try:
         resp = requests.get(f"{BACKEND_URL}/status", timeout=5)
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        data["available"] = True
+        return data
     except Exception:
-        return None
+        return {"available": False}

--- a/tests/test_profile_settings.py
+++ b/tests/test_profile_settings.py
@@ -15,8 +15,6 @@ from profile_adapter import update_profile_adapter  # noqa: E402
 
 @pytest.mark.requires_streamlit
 def test_update_profile_stub(monkeypatch):
-    st.session_state.clear()
-    st.session_state["use_backend"] = False
     called = {"count": 0}
 
     def fake_put(*args, **kwargs):
@@ -29,16 +27,14 @@ def test_update_profile_stub(monkeypatch):
         return Resp()
 
     monkeypatch.setattr("profile_adapter.requests.put", fake_put)
-    result = update_profile_adapter("hello", ["music"])
+    result = update_profile_adapter("hello", ["music"], use_backend=False)
     assert result["status"] == "stubbed"
+    assert result["available"]
     assert called["count"] == 0
 
 
 @pytest.mark.requires_streamlit
 def test_update_profile_backend(monkeypatch):
-    st.session_state.clear()
-    st.session_state["use_backend"] = True
-
     def fake_put(url, json, timeout):
         assert json == {"bio": "hello", "cultural_preferences": ["music"]}
 
@@ -49,13 +45,13 @@ def test_update_profile_backend(monkeypatch):
         return Resp()
 
     monkeypatch.setattr("profile_adapter.requests.put", fake_put)
-    result = update_profile_adapter("hello", ["music"])
+    result = update_profile_adapter("hello", ["music"], use_backend=True)
     assert result["status"] == "ok"
+    assert result["available"]
 
 
 @pytest.mark.requires_streamlit
 def test_update_profile_validation_error(monkeypatch):
-    st.session_state.clear()
-    st.session_state["use_backend"] = True
-    result = update_profile_adapter("", ["music"])
+    result = update_profile_adapter("", ["music"], use_backend=True)
     assert result["status"] == "error"
+    assert result["available"]

--- a/tests/test_signup_adapter.py
+++ b/tests/test_signup_adapter.py
@@ -13,12 +13,12 @@ def test_stub_signup(monkeypatch):
     importlib.reload(signup_adapter)
     signup_adapter.reset_stub()
 
-    ok, _ = signup_adapter.register_user("alice", "a@example.com", "password123")
-    assert ok
-    ok, msg = signup_adapter.register_user("alice", "b@example.com", "password123")
-    assert not ok and "exists" in msg.lower()
-    ok, msg = signup_adapter.register_user("bob", "a@example.com", "password123")
-    assert not ok and "exists" in msg.lower()
+    resp = signup_adapter.register_user("alice", "a@example.com", "password123")
+    assert resp["ok"]
+    resp = signup_adapter.register_user("alice", "b@example.com", "password123")
+    assert not resp["ok"] and "exists" in resp["error"].lower()
+    resp = signup_adapter.register_user("bob", "a@example.com", "password123")
+    assert not resp["ok"] and "exists" in resp["error"].lower()
 
 
 def test_backend_signup(tmp_path, monkeypatch):
@@ -39,9 +39,9 @@ def test_backend_signup(tmp_path, monkeypatch):
     superNova_2177.Base.metadata.create_all(bind=superNova_2177.engine)
     importlib.reload(signup_adapter)
 
-    ok, _ = signup_adapter.register_user("carol", "c@example.com", "password123")
-    assert ok
-    ok, msg = signup_adapter.register_user("carol", "d@example.com", "password123")
-    assert not ok and "exists" in msg.lower()
-    ok, msg = signup_adapter.register_user("dave", "c@example.com", "password123")
-    assert not ok and "exists" in msg.lower()
+    resp = signup_adapter.register_user("carol", "c@example.com", "password123")
+    assert resp["ok"]
+    resp = signup_adapter.register_user("carol", "d@example.com", "password123")
+    assert not resp["ok"] and "exists" in resp["error"].lower()
+    resp = signup_adapter.register_user("dave", "c@example.com", "password123")
+    assert not resp["ok"] and "exists" in resp["error"].lower()

--- a/tests/test_system_status_page.py
+++ b/tests/test_system_status_page.py
@@ -22,7 +22,7 @@ def test_status_page_placeholders_when_disabled(monkeypatch):
     dummy_st = types.SimpleNamespace(
         toggle=lambda *a, **k: False,
         metric=lambda label, value: metrics.append((label, value)),
-        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
     )
     monkeypatch.setattr(status_page, "st", dummy_st)
     status_page.main()
@@ -36,15 +36,16 @@ def test_status_page_shows_metrics(monkeypatch):
     dummy_st = types.SimpleNamespace(
         toggle=lambda *a, **k: True,
         metric=lambda label, value: metrics.append((label, value)),
-        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
     )
     monkeypatch.setattr(status_page, "st", dummy_st)
     sample = {
+        "available": True,
         "metrics": {
             "total_harmonizers": 3,
             "total_vibenodes": 5,
             "current_system_entropy": 0.42,
-        }
+        },
     }
     monkeypatch.setattr(status_page, "get_status", lambda: sample)
     status_page.main()

--- a/utils/api_keys.py
+++ b/utils/api_keys.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Helper utilities for retrieving API keys.
+
+This module centralizes access to API keys. It first checks ``st.secrets``
+for a key suffixed with ``"_v2"`` and falls back to environment variables.
+It never raises if ``st`` or the secret is unavailable.
+"""
+
+import os
+from typing import Optional
+
+try:  # pragma: no cover - streamlit may be unavailable during tests
+    import streamlit as st  # type: ignore
+except Exception:  # pragma: no cover
+    st = None  # type: ignore
+
+
+def get_api_key(env_key: str) -> str:
+    """Retrieve an API key from ``st.secrets`` or ``os.environ``.
+
+    Parameters
+    ----------
+    env_key:
+        The name of the environment variable (e.g. ``"OPENAI_API_KEY"``).
+
+    Returns
+    -------
+    str
+        The API key if found, otherwise an empty string.
+    """
+    secret_key = f"{env_key}_v2"
+    if st is not None:
+        try:
+            secret = st.secrets.get(secret_key, "")  # type: ignore[arg-type]
+            if isinstance(secret, str) and secret.strip():
+                return secret.strip()
+        except Exception:
+            pass
+    return os.getenv(env_key, "").strip()
+
+
+__all__ = ["get_api_key"]


### PR DESCRIPTION
## Summary
- add `get_api_key` helper that reads `*_v2` secrets with env fallback
- guard backend adapters against import/call failures and expose `available` flag
- show warnings when services unavailable and avoid duplicate Streamlit keys

## Testing
- `pytest tests/test_signup_adapter.py tests/test_profile_settings.py tests/test_system_status_page.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895695cfa748320920e9d7d9d2ca4c7