### PR TITLE
docs: outline feature adapters and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ python -m pip install -r requirements.txt
 streamlit run ui.py
 ````
 
+## 🔗 How to open the new pages
+
+> STRICTLY A SOCIAL MEDIA PLATFORM  
+> Intellectual Property & Artistic Inspiration  
+> Legal & Ethical Safeguards
+
+Launch the Streamlit server:
+
+```bash
+streamlit run ui.py
+```
+
+Then navigate using the sidebar:
+
+1. **Karma:** `Sidebar → Karma`
+2. **Harmonizer:** `Sidebar → Harmonizer`
+3. **Validators:** `Sidebar → Validators`
+
 ## 🗳️ How voting works
 
 > STRICTLY A SOCIAL MEDIA PLATFORM

--- a/docs/FEATURE_INVENTORY.md
+++ b/docs/FEATURE_INVENTORY.md
@@ -1,0 +1,14 @@
+> STRICTLY A SOCIAL MEDIA PLATFORM  
+> Intellectual Property & Artistic Inspiration  
+> Legal & Ethical Safeguards
+
+# Feature Inventory
+
+| Feature Page | Adapter Function | Backend Endpoint | Stub Needed? |
+|--------------|-----------------|------------------|--------------|
+| Karma        | `get_karma_adapter(user_id)`      | `/api/karma/<user_id>`     | Yes - endpoint absent |
+| Harmonizer   | `harmonizers_adapter()`           | `/api/harmonizers`         | Yes - endpoint absent |
+| Validators   | `validators_adapter()`            | `/api/validators`          | Yes - endpoint absent |
+
+These pages currently rely on stub data until their respective backend endpoints are implemented.
+

--- a/docs/FEATURE_PAGES.md
+++ b/docs/FEATURE_PAGES.md
@@ -1,0 +1,48 @@
+> STRICTLY A SOCIAL MEDIA PLATFORM  
+> Intellectual Property & Artistic Inspiration  
+> Legal & Ethical Safeguards
+
+# Feature Pages
+
+This guide outlines the adapters powering the Karma, Harmonizer, and Validators feature pages. Each adapter mirrors an HTTP endpoint and falls back to stub data when the backend is unavailable.
+
+## Karma Adapter
+
+```python
+from typing import Dict, Any, Optional, Tuple
+
+def get_karma_adapter(user_id: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Fetch a user's karma stats.
+
+    Returns (data, error). In stub mode, returns example data.
+    """
+```
+
+## Harmonizer Adapter
+
+```python
+from typing import List, Dict, Any, Optional, Tuple
+
+def harmonizers_adapter() -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    """List active harmonizers.
+
+    Returns (harmonizers, error). Provides sample records when the backend is down.
+    """
+```
+
+## Validators Adapter
+
+```python
+from typing import List, Dict, Any, Optional, Tuple
+
+def validators_adapter() -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    """Retrieve registered validators.
+
+    Returns (validators, error). Supplies placeholder entries when no backend is connected.
+    """
+```
+
+### Fallback Behavior
+
+All adapters check the `USE_REAL_BACKEND` environment variable. When set to a falsey value or the service request fails, the functions return stubbed data and an error message of `None`. This keeps the UI responsive even if the backend is offline.
+


### PR DESCRIPTION
## Summary
- document karma, harmonizer, and validators adapter APIs
- record feature inventory with stub status
- add README instructions for navigating new pages

## Testing
- `pytest -q` *(fails: AttributeError in ui and streamlit helpers; KeyError in theme)*

------
https://chatgpt.com/codex/tasks/task_e_6895695c0cf48320aff95ea8c929a71f