### PR TITLE
Namespace widget keys across pages

### DIFF
--- a/pages/resonance_music.py
+++ b/pages/resonance_music.py
@@ -32,19 +32,37 @@ from utils.api import (
     get_resonance_summary,
     dispatch_route,
 )
+from .widget_keys import (
+    page_key,
+    RESONANCE_MUSIC_PAGE,
+)
+
+# Dedicated keys for this page to avoid collisions across Streamlit pages.
+# The `_v2` suffix is added via ``page_key`` to signal the new naming scheme.
+STATUS_PING_KEY = page_key(RESONANCE_MUSIC_PAGE, "status_ping")
+AMBIENT_LOOP_TOGGLE_KEY = page_key(RESONANCE_MUSIC_PAGE, "ambient_loop_toggle")
+PROFILE_SELECT_KEY = page_key(RESONANCE_MUSIC_PAGE, "profile_select")
+GENERATE_MUSIC_BTN_KEY = page_key(RESONANCE_MUSIC_PAGE, "generate_music_btn")
+FETCH_SUMMARY_BTN_KEY = page_key(RESONANCE_MUSIC_PAGE, "fetch_summary_btn")
+SUMMARY_AUDIO_PLAYER_KEY = page_key(
+    RESONANCE_MUSIC_PAGE,
+    "summary_audio_player",
+)
 
 # Initialize theme & global styles once
 apply_theme("light")
 inject_global_styles()
 
-# BACKEND_URL is defined in utils.api, but we keep it here for direct requests calls if needed
+# BACKEND_URL is defined in utils.api, but we keep it here for direct requests
+# if needed.
 BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 AMBIENT_URL = os.getenv(
     "AMBIENT_MP3_URL",
     "https://raw.githubusercontent.com/anars/blank-audio/master/10-minutes-of-silence.mp3",
 )
 DEFAULT_AMBIENT_URL = (
-    "https://raw.githubusercontent.com/anars/blank-audio/master/10-seconds-of-silence.mp3"
+    "https://raw.githubusercontent.com/anars/blank-audio/master/"
+    "10-seconds-of-silence.mp3"
 )
 
 
@@ -86,7 +104,7 @@ def main(main_container=None, status_container=None) -> None:
     theme_toggle("Dark Mode", key_suffix="music")
 
     # Auto-refresh for backend health check (global, outside main_container)
-    st_autorefresh(interval=30000, key="status_ping")
+    st_autorefresh(interval=30000, key=STATUS_PING_KEY)
 
     # Render global backend status indicator in the provided container
     status_ctx = safe_container(status_container)
@@ -97,7 +115,10 @@ def main(main_container=None, status_container=None) -> None:
     backend_ok = check_backend(endpoint="/healthz")
     if not backend_ok:
         alert(
-            f"Backend service unreachable. Please ensure it is running at {BACKEND_URL}.",
+            (
+                "Backend service unreachable. Please ensure it is running "
+                f"at {BACKEND_URL}."
+            ),
             "error",
         )
 
@@ -124,7 +145,7 @@ def render_resonance_music_page(
         play_music = st.toggle(
             "🎵 Ambient Loop",
             value=st.session_state["ambient_enabled"],
-            key="ambient_loop_toggle",
+            key=AMBIENT_LOOP_TOGGLE_KEY,
         )
         st.session_state["ambient_enabled"] = play_music
         if play_music:
@@ -132,15 +153,23 @@ def render_resonance_music_page(
             if audio_bytes:
                 encoded = base64.b64encode(audio_bytes).decode()
                 st.markdown(
-                    f"<audio id='ambient-audio' autoplay loop style='display:none'>"
-                    f"<source src='data:audio/mp3;base64,{encoded}' type='audio/mp3'></audio>",
+                    (
+                        "<audio id='ambient-audio' autoplay loop style='display:none'>"
+                        f"<source src='data:audio/mp3;base64,{encoded}' "
+                        "type='audio/mp3'></audio>"
+                    ),
                     unsafe_allow_html=True,
                 )
             else:
                 st.error("Failed to load ambient music. Please try again later.")
         else:
             st.markdown(
-                "<script>var a=document.getElementById('ambient-audio');if(a){a.pause();a.remove();}</script>",
+                (
+                    "<script>"
+                    "var a=document.getElementById('ambient-audio');"
+                    "if(a){a.pause();a.remove();}"
+                    "</script>"
+                ),
                 unsafe_allow_html=True,
             )
 
@@ -153,16 +182,19 @@ def render_resonance_music_page(
             combined_options,
             index=0,
             placeholder="tracks or resonance profiles",
-            key="resonance_profile_select",
+            key=PROFILE_SELECT_KEY,
         )
 
         midi_placeholder = st.empty()
 
         # --- Generate Music Section ---
-        if st.button("Generate music", key="generate_music_btn"):
+        if st.button("Generate music", key=GENERATE_MUSIC_BTN_KEY):
             if not backend_ok:
                 alert(
-                    f"Cannot generate music: Backend service unreachable at {BACKEND_URL}.",
+                    (
+                        "Cannot generate music: Backend service unreachable "
+                        f"at {BACKEND_URL}."
+                    ),
                     "error",
                 )
                 return
@@ -185,15 +217,19 @@ def render_resonance_music_page(
                 except Exception as exc:
                     alert(
                         "Music generation failed: "
-                        f"{exc}. Ensure backend is running and 'generate_midi' route is available.",
+                        f"{exc}. Ensure backend is running and "
+                        "'generate_midi' route is available.",
                         "error",
                     )
 
         # --- Fetch Resonance Summary Section ---
-        if st.button("Fetch resonance summary", key="fetch_summary_btn"):
+        if st.button("Fetch resonance summary", key=FETCH_SUMMARY_BTN_KEY):
             if not backend_ok:
                 alert(
-                    f"Cannot fetch summary: Backend service unreachable at {BACKEND_URL}.",
+                    (
+                        "Cannot fetch summary: Backend service unreachable "
+                        f"at {BACKEND_URL}."
+                    ),
                     "error",
                 )
                 return
@@ -204,7 +240,8 @@ def render_resonance_music_page(
                 except Exception as exc:
                     alert(
                         "Failed to load summary: "
-                        f"{exc}. Ensure backend is running and 'resonance-summary' route is available.",
+                        f"{exc}. Ensure backend is running and "
+                        "'resonance-summary' route is available.",
                         "error",
                     )
                 else:
@@ -233,7 +270,7 @@ def render_resonance_music_page(
                             st.audio(
                                 summary_midi_bytes,
                                 format="audio/midi",
-                                key="summary_audio_player",
+                                key=SUMMARY_AUDIO_PLAYER_KEY,
                             )
                             st.toast("Playing associated MIDI from summary.")
 

--- a/pages/video_chat.py
+++ b/pages/video_chat.py
@@ -9,6 +9,14 @@ from frontend.theme import apply_theme
 from ai_video_chat import create_session
 from video_chat_router import ConnectionManager
 from streamlit_helpers import safe_container, header, theme_toggle, inject_global_styles
+from .widget_keys import page_key, VIDEO_CHAT_PAGE
+
+# Dedicated widget keys for this page. The helper appends a shared `_v2`
+# suffix so new pages don't collide with legacy keys.
+VIDEO_CHAT_START_KEY = page_key(VIDEO_CHAT_PAGE, "start")
+VIDEO_CHAT_END_KEY = page_key(VIDEO_CHAT_PAGE, "end")
+VIDEO_CHAT_INPUT_KEY = page_key(VIDEO_CHAT_PAGE, "input")
+VIDEO_CHAT_SEND_KEY = page_key(VIDEO_CHAT_PAGE, "send")
 
 # Initialize theme & global styles once on import
 apply_theme("light")
@@ -43,27 +51,27 @@ def main(main_container=None) -> None:
         messages = st.session_state.setdefault("video_chat_messages", [])
 
         if session is None:
-            if st.button("Start Session", key="video_chat_start"):
+            if st.button("Start Session", key=VIDEO_CHAT_START_KEY):
                 session = create_session(["local-user"])
                 _run_async(session.start())
                 st.session_state["video_chat_session"] = session
                 st.success("Session started")
         else:
             st.write(f"Session ID: {session.session_id}")
-            if st.button("End Session", key="video_chat_end"):
+            if st.button("End Session", key=VIDEO_CHAT_END_KEY):
                 _run_async(session.end())
                 st.session_state["video_chat_session"] = None
                 st.session_state["video_chat_messages"] = []
                 st.success("Session ended")
                 return
 
-            msg = st.text_input("Message", key="video_chat_input")
-            if st.button("Send", key="video_chat_send"):
+            msg = st.text_input("Message", key=VIDEO_CHAT_INPUT_KEY)
+            if st.button("Send", key=VIDEO_CHAT_SEND_KEY):
                 if msg:
                     payload = {"type": "chat", "text": msg, "lang": "en"}
                     _run_async(manager.broadcast(payload, sender=None))
                     messages.append(f"You: {msg}")
-                    st.session_state["video_chat_input"] = ""
+                    st.session_state[VIDEO_CHAT_INPUT_KEY] = ""
 
             st.markdown("**Chat Log**")
             for line in messages:

--- a/pages/widget_keys.py
+++ b/pages/widget_keys.py
@@ -1,0 +1,27 @@
+"""Central helpers for Streamlit widget keys.
+
+Ensures uniqueness across pages by applying a common naming scheme.
+"""
+
+from __future__ import annotations
+
+# Suffix applied to all widget keys to signal the v2 naming scheme.
+_KEY_SUFFIX = "_v2"
+
+
+def page_key(page: str, name: str) -> str:
+    """Return a namespaced widget key for ``name`` on ``page``.
+
+    Examples
+    --------
+    >>> page_key("resonance_music", "status_ping")
+    'resonance_music_status_ping_v2'
+    """
+
+    return f"{page}_{name}{_KEY_SUFFIX}"
+
+
+# Page identifiers used throughout the repo. Documenting them here helps
+# maintainers keep track of the keys reserved by each page.
+RESONANCE_MUSIC_PAGE = "resonance_music"
+VIDEO_CHAT_PAGE = "video_chat"


### PR DESCRIPTION
## Summary
- centralize Streamlit widget key naming with a `page_key` helper and `_v2` suffix
- switch resonance music and video chat pages to dedicated key constants to avoid collisions

## Testing
- `pre-commit run --files pages/resonance_music.py pages/video_chat.py pages/widget_keys.py`
- `pytest` *(fails: AttributeError: module 'ui' has no attribute '_determine_backend', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6895690fb69883209795010ed701c9ba