### PR TITLE
feat: add openai key helper and warnings

### DIFF
--- a/pages/agents.py
+++ b/pages/agents.py
@@ -1,28 +1,12 @@
 # pages/agents.py
 from __future__ import annotations
+
 import os
 import streamlit as st
 
+from api_key_input import read_openai_key
+
 PAGE = "agents"  # prefix so all widget keys on this page are unique
-
-
-def _default_openai_key() -> str:
-    """Prefer session -> secrets -> env, but never crash if secrets.toml is absent."""
-    # 1) session
-    val = st.session_state.get("openai_api_key")
-    if isinstance(val, str) and val.strip():
-        return val.strip()
-
-    # 2) secrets (guarded so it doesn't raise when file doesn't exist)
-    try:
-        secret = st.secrets["openai_api_key"]  # type: ignore[index]
-        if isinstance(secret, str) and secret.strip():
-            return secret.strip()
-    except Exception:
-        pass
-
-    # 3) environment
-    return os.environ.get("OPENAI_API_KEY", "").strip()
 
 
 def render() -> None:
@@ -31,17 +15,20 @@ def render() -> None:
     with st.form(f"{PAGE}_api_form"):
         key_input = st.text_input(
             "OpenAI API key",
-            value=_default_openai_key(),
+            value=read_openai_key(),
             type="password",
             placeholder="sk-...",
-            key=f"{PAGE}_openai_api_key",  # ONE unique key only
+            key=f"{PAGE}_openai_api_key_v2",  # unique key with suffix
         )
         saved = st.form_submit_button("Save")
 
     if saved:
         st.session_state["openai_api_key"] = key_input.strip()
         os.environ["OPENAI_API_KEY"] = st.session_state["openai_api_key"]
-        st.success("Saved. Agents will use this key.")
+        if key_input.strip():
+            st.success("Saved. Agents will use this key.")
+        else:
+            st.warning("No API key provided; OpenAI-powered agents are disabled.")
 
     st.caption(
         "Tip: you can also set this in `.streamlit/secrets.toml` as "

--- a/transcendental_resonance_frontend/tr_pages/animate_gaussion.py
+++ b/transcendental_resonance_frontend/tr_pages/animate_gaussion.py
@@ -1017,7 +1017,10 @@ with left_col:
     with st.expander("Agent Configuration"):
         api_info = render_api_key_ui(key_prefix="devtools")
         backend_choice = api_info.get("model", "dummy")
-        api_key = api_info.get("api_key", "") or ""
+        api_key = api_info.get("api_key") or ""
+        run_agent_disabled = api_info.get("disabled", False)
+        if run_agent_disabled:
+            st.warning("API key required for selected model.")
         if AGENT_REGISTRY:
             agent_choice = st.selectbox(
                 "Agent",
@@ -1029,7 +1032,7 @@ with left_col:
             st.info("No agents registered")
         event_type = st.text_input("Event", value="LLM_INCOMING")
         payload_txt = st.text_area("Payload JSON", value="{}", height=100)
-        run_agent_clicked = st.button("Run Agent")
+        run_agent_clicked = st.button("Run Agent", disabled=run_agent_disabled)
     with st.expander("Simulation Tools"):
         render_simulation_stubs()
     st.divider()


### PR DESCRIPTION
## Summary
- add `read_openai_key` helper to load keys from session, secrets or environment
- warn and disable LLM actions when API key missing
- switch API key widget keys to unique `_v2` names

## Testing
- `pytest` *(fails: module 'ui' has no attribute '...')*

------
https://chatgpt.com/codex/tasks/task_e_6895691072d48320b2c29f321d32253c